### PR TITLE
add code climate analysis platform link

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,4 @@ Web frameworks
 * [Ratpack](https://github.com/ratpack/ratpack) - A toolkit for JVM web applications .
 * [Spark](https://github.com/perwendel/spark) - A Sinatra inspired framework for java.
 * [Vert.x](https://github.com/eclipse/vert.x/) - Vert.x is a tool-kit for building reactive applications on the JVM.
+* [Code Climate/codeclimate](https://github.com/codeclimate/codeclimate) - Code Climate’s engineering process insights and automated code review for GitHub.


### PR DESCRIPTION
This PR adds a link to Code Climate, which is a command line interface for the Code Climate analysis platform. In code on Github It allows you to run Code Climate engines on your local machine inside of Docker containers.