### PR TITLE
Add tinylog

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Logging
 -------
 * [blitz4j](https://github.com/Netflix/blitz4j) - Logging framework for fast asynchronous logging.
 * [log4j2](https://logging.apache.org/log4j/2.x/) - Async Loggers have 18 times higher throughput than Log4j 1.x and Logback.
+* [tinylog](https://tinylog.org/) - Simple logging framework without boilerplate code.
 
 Math & ML
 ---------


### PR DESCRIPTION
This adds [tinylog](https://tinylog.org/) to the list of loggers.

It's awesome, because no boilerplate-code is needed (and it also offers an SLF4J implementation if one does not want to use it directly)

```java
import org.tinylog.Logger;

public class Application {

    public static void main(String[] args) {
        Logger.info("Hello World!");
    }

}
```